### PR TITLE
new command line option --process-url

### DIFF
--- a/bricolage-streaming-preprocessor
+++ b/bricolage-streaming-preprocessor
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+JAVAOPTS=${JAVAOPTS:-""}
+if [[ -n $LOGBACK_CONFIG ]]
+then
+    JAVAOPTS="$JAVAOPTS -Dlogging.config=$LOGBACK_CONFIG"
+fi
+java $JAVAOPTS -jar build/libs/bricolage-streaming-preprocessor.jar "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 gradle build &&
-java -Dlogging.config=config/logback.xml -jar build/libs/bricolage-streaming-preprocessor.jar "$@"
+LOGBACK_CONFIG=config/logback.xml $(dirname $0)/bricolage-streaming-preprocessor "$@"


### PR DESCRIPTION
Adds new option --process-url=S3URL, which processes a S3 file as configured, then print result to stdout.  You can utilize this option to test new table filter definitions.