### PR TITLE
Sends SQS message by myself, instead of depending on S3 ObjectCreated event

### DIFF
--- a/db/preproc_log.schema
+++ b/db/preproc_log.schema
@@ -8,4 +8,5 @@ create_table "preproc_log", id: :bigserial, force: :cascade do |t|
   t.datetime "start_time"
   t.datetime "end_time"
   t.text     "message"
+  t.boolean  "dispatched", default: false
 end

--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -1,6 +1,7 @@
 package org.bricolages.streaming;
 import org.bricolages.streaming.filter.ObjectFilterFactory;
 import org.bricolages.streaming.event.EventQueue;
+import org.bricolages.streaming.event.LogQueue;
 import org.bricolages.streaming.event.SQSQueue;
 import org.bricolages.streaming.s3.S3Agent;
 import org.bricolages.streaming.s3.ObjectMapper;
@@ -135,17 +136,24 @@ public class Application {
 
     @Bean
     public Preprocessor preprocessor() {
-        return new Preprocessor(eventQueue(), s3(), mapper(), filterFactory());
+        return new Preprocessor(eventQueue(), logQueue(), s3(), mapper(), filterFactory());
     }
 
     @Bean
     public EventQueue eventQueue() {
-        val config = getConfig().queue;
+        val config = getConfig().eventQueue;
         val sqs = new SQSQueue(new AmazonSQSClient(), config.url);
         if (config.visibilityTimeout > 0) sqs.setVisibilityTimeout(config.visibilityTimeout);
         if (config.maxNumberOfMessages > 0) sqs.setMaxNumberOfMessages(config.maxNumberOfMessages);
         if (config.waitTimeSeconds > 0) sqs.setWaitTimeSeconds(config.waitTimeSeconds);
         return new EventQueue(sqs);
+    }
+
+    @Bean
+    public LogQueue logQueue() {
+        val config = getConfig().logQueue;
+        val sqs = new SQSQueue(new AmazonSQSClient(), config.url);
+        return new LogQueue(sqs);
     }
 
     @Bean

--- a/src/main/java/org/bricolages/streaming/Config.java
+++ b/src/main/java/org/bricolages/streaming/Config.java
@@ -34,13 +34,18 @@ class Config {
         return new Yaml().loadAs(in, Config.class);
     }
 
-    public QueueEntry queue;
+    public ReceiveQueueEntry eventQueue;
+    public SendQueueEntry logQueue;
     public List<ObjectMapper.Entry> mapping;
 
-    static final class QueueEntry {
+    static final class ReceiveQueueEntry {
         public String url;
         public int visibilityTimeout;
         public int maxNumberOfMessages;
         public int waitTimeSeconds;
+    }
+
+    static final class SendQueueEntry {
+        public String url;
     }
 }

--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -192,6 +192,8 @@ public class Preprocessor implements EventHandlers {
             repos.save(result);
             if (!event.doesNotDispatch()) {
                 logQueue.send(new FakeS3Event(obj));
+                result.dispatched();
+                repos.save(result);
             }
             eventQueue.deleteAsync(event);
         }

--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -185,8 +185,8 @@ public class Preprocessor implements EventHandlers {
         FilterResult result = new FilterResult(src.urlString(), dest.urlString());
         try {
             repos.save(result);
-            ObjectFilter filter = filterFactory.load(mapResult.getTableId());
-            S3ObjectMetadata obj = applyFilter(filter, src, dest, result);
+            ObjectFilter filter = filterFactory.load(table);
+            S3ObjectMetadata obj = applyFilter(filter, src, dest, result, table);
             log.debug("src: {}, dest: {}, in: {}, out: {}", src.urlString(), dest.urlString(), result.inputRows, result.outputRows);
             result.succeeded();
             repos.save(result);
@@ -202,8 +202,8 @@ public class Preprocessor implements EventHandlers {
         }
     }
 
-    S3ObjectMetadata applyFilter(ObjectFilter filter, S3ObjectLocation src, S3ObjectLocation dest, FilterResult result) throws S3IOException, IOException {
-        try (S3Agent.Buffer buf = s3.openWriteBuffer(dest)) {
+    S3ObjectMetadata applyFilter(ObjectFilter filter, S3ObjectLocation src, S3ObjectLocation dest, FilterResult result, TableId table) throws S3IOException, IOException {
+        try (S3Agent.Buffer buf = s3.openWriteBuffer(dest, table.toString())) {
             try (BufferedReader r = s3.openBufferedReader(src)) {
                 filter.apply(r, buf.getBufferedWriter(), src.toString(), result);
             }

--- a/src/main/java/org/bricolages/streaming/event/FakeS3Event.java
+++ b/src/main/java/org/bricolages/streaming/event/FakeS3Event.java
@@ -1,0 +1,37 @@
+package org.bricolages.streaming.event;
+import org.bricolages.streaming.s3.S3ObjectLocation;
+import org.bricolages.streaming.s3.S3ObjectMetadata;
+import lombok.*;
+
+@RequiredArgsConstructor
+public class FakeS3Event extends LogQueueEvent {
+    final S3ObjectMetadata object;
+
+    @Override
+    public String messageBody() {
+        val w = new SQSMessageBodyWriter();
+        w.beginObject();
+            w.beginArray("Records");
+                w.beginObject();
+                    w.pair("eventVersion", "2.0");
+                    w.pair("eventSource", "bricolage:preprocessor");
+                    w.pair("eventTime", object.createdTime());
+                    w.pair("eventName", "ObjectCreated:Put");
+                    w.beginObject("s3");
+                        w.pair("s3SchemaVersion", "1.0");
+                        w.beginObject("bucket");
+                            w.pair("name", object.bucket());
+                        w.endObject();
+                        w.beginObject("object");
+                            w.pair("key", object.key());
+                            w.pair("size", object.size());
+                            if (object.eTag() != null)
+                                w.pair("eTag", object.eTag());
+                        w.endObject();
+                    w.endObject();
+                w.endObject();
+            w.endArray();
+        w.endObject();
+        return w.toString();
+    }
+}

--- a/src/main/java/org/bricolages/streaming/event/LogQueue.java
+++ b/src/main/java/org/bricolages/streaming/event/LogQueue.java
@@ -1,0 +1,13 @@
+package org.bricolages.streaming.event;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class LogQueue {
+    final SQSQueue queue;
+
+    public void send(LogQueueEvent e) {
+        queue.sendMessage(e.messageBody());
+    }
+}

--- a/src/main/java/org/bricolages/streaming/event/LogQueueEvent.java
+++ b/src/main/java/org/bricolages/streaming/event/LogQueueEvent.java
@@ -1,0 +1,5 @@
+package org.bricolages.streaming.event;
+
+public abstract class LogQueueEvent {
+    public abstract String messageBody();
+}

--- a/src/main/java/org/bricolages/streaming/event/SQSMessageBodyWriter.java
+++ b/src/main/java/org/bricolages/streaming/event/SQSMessageBodyWriter.java
@@ -1,0 +1,91 @@
+package org.bricolages.streaming.event;
+import java.util.regex.Pattern;
+import java.time.Instant;
+import lombok.*;
+
+@NoArgsConstructor
+public class SQSMessageBodyWriter {
+    StringBuilder buf = new StringBuilder();
+    boolean needSeparator = false;
+
+    @Override
+    public String toString() {
+        return buf.toString();
+    }
+
+    public SQSMessageBodyWriter append(String s) {
+        buf.append(s);
+        return this;
+    }
+
+    public SQSMessageBodyWriter pair(String key, String value) {
+        return key(key).value(value);
+    }
+
+    public SQSMessageBodyWriter pair(String key, long value) {
+        return key(key).value(value);
+    }
+
+    public SQSMessageBodyWriter pair(String key, Instant value) {
+        return key(key).value(value);
+    }
+
+    public SQSMessageBodyWriter key(String key) {
+        if (needSeparator) {
+            buf.append(",");
+            this.needSeparator = false;
+        }
+        buf.append("\"").append(key).append("\":");
+        return this;
+    }
+
+    public SQSMessageBodyWriter value(long value) {
+        return value(Long.toString(value));
+    }
+
+    public SQSMessageBodyWriter value(Instant t) {
+        return value(t.toString());
+    }
+
+    public SQSMessageBodyWriter value(String value) {
+        buf.append("\"").append(escapeString(value)).append("\"");
+        this.needSeparator = true;
+        return this;
+    }
+
+    static final Pattern ESCAPE_CHARS = Pattern.compile("[\\\\\"]");
+
+    public String escapeString(String str) {
+        return ESCAPE_CHARS.matcher(str).replaceAll("\\\\$&");
+    }
+
+    public SQSMessageBodyWriter beginObject(String key) {
+        return key(key).beginObject();
+    }
+
+    public SQSMessageBodyWriter beginObject() {
+        buf.append("{");
+        return this;
+    }
+
+    public SQSMessageBodyWriter endObject() {
+        buf.append("}");
+        this.needSeparator = true;
+        return this;
+    }
+
+    public SQSMessageBodyWriter beginArray(String key) {
+        return key(key).beginArray();
+    }
+
+    public SQSMessageBodyWriter beginArray() {
+        buf.append("[");
+        return this;
+    }
+
+    public SQSMessageBodyWriter endArray() {
+        buf.append("]");
+        this.needSeparator = true;
+        return this;
+    }
+}

--- a/src/main/java/org/bricolages/streaming/event/SQSQueue.java
+++ b/src/main/java/org/bricolages/streaming/event/SQSQueue.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.sqs.model.DeleteMessageRequest;
 import com.amazonaws.services.sqs.model.DeleteMessageResult;
 import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AbortedException;
 import java.util.List;
@@ -92,6 +93,18 @@ public class SQSQueue implements Iterable<Message> {
         }
         catch (AmazonClientException ex) {
             String msg = "deleteMessageBatch failed: " + ex.getMessage();
+            log.error(msg);
+            throw new SQSException(msg);
+        }
+    }
+
+    public SendMessageResult sendMessage(String body) {
+        try {
+            log.info("sendMessage queue={}", queueUrl);
+            return sqs.sendMessage(queueUrl, body);
+        }
+        catch (AmazonClientException ex) {
+            String msg = "sendMessage failed: " + ex.getMessage();
             log.error(msg);
             throw new SQSException(msg);
         }

--- a/src/main/java/org/bricolages/streaming/filter/FilterResult.java
+++ b/src/main/java/org/bricolages/streaming/filter/FilterResult.java
@@ -45,6 +45,9 @@ public class FilterResult {
     @Column(name="message")
     String message;
 
+    @Column(name="dispatched")
+    boolean dispatched;
+
     public FilterResult(String src, String dest) {
         this.srcDataFile = src;
         this.destDataFile = dest;
@@ -64,5 +67,9 @@ public class FilterResult {
 
     Timestamp currentTimestamp() {
         return new Timestamp(System.currentTimeMillis());
+    }
+
+    public void dispatched() {
+        this.dispatched = true;
     }
 }

--- a/src/main/java/org/bricolages/streaming/s3/S3Agent.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3Agent.java
@@ -87,8 +87,8 @@ public class S3Agent {
         }
     }
 
-    public Buffer openWriteBuffer(S3ObjectLocation dest) throws S3IOException {
-        Path tmp = Paths.get(TMPDIR, dest.basename());
+    public Buffer openWriteBuffer(S3ObjectLocation dest, String uniqPrefix) throws S3IOException {
+        Path tmp = Paths.get(TMPDIR, uniqPrefix + "-" + dest.basename());
         return new Buffer(tmp, dest);
     }
 

--- a/src/main/java/org/bricolages/streaming/s3/S3ObjectLocation.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3ObjectLocation.java
@@ -37,6 +37,14 @@ public class S3ObjectLocation {
         return this.urlString;
     }
 
+    public String bucket() {
+        return this.bucket;
+    }
+
+    public String key() {
+        return this.key;
+    }
+
     public String basename() {
         return Paths.get(key).getFileName().toString();
     }

--- a/src/main/java/org/bricolages/streaming/s3/S3ObjectMetadata.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3ObjectMetadata.java
@@ -1,0 +1,49 @@
+package org.bricolages.streaming.s3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.util.Date;
+import java.time.Instant;
+import lombok.*;
+
+@RequiredArgsConstructor
+public class S3ObjectMetadata {
+    final S3ObjectLocation location;
+    final ObjectMetadata meta;
+
+    public S3ObjectMetadata(S3ObjectLocation loc, Instant createdTime, long size, String eTag) {
+        this(loc, makeObjectMetadata(createdTime, size, eTag));
+    }
+
+    // For tests
+    public S3ObjectMetadata(String url, Instant createdTime, long size, String eTag) throws S3UrlParseException {
+        this(S3ObjectLocation.forUrl(url), makeObjectMetadata(createdTime, size, eTag));
+    }
+
+    static ObjectMetadata makeObjectMetadata(Instant createdTime, long size, String eTag) {
+        val meta = new ObjectMetadata();
+        meta.setLastModified(new Date(createdTime.toEpochMilli()));
+        meta.setContentLength(size);
+        meta.setHeader("ETag", eTag);
+        return meta;
+    }
+
+    public String bucket() {
+        return location.bucket();
+    }
+
+    public String key() {
+        return location.key();
+    }
+
+    public Instant createdTime() {
+        Date d = meta.getLastModified();
+        return Instant.ofEpochMilli(d.getTime());
+    }
+
+    public long size() {
+        return meta.getContentLength();
+    }
+
+    public String eTag() {
+        return meta.getETag();
+    }
+}

--- a/src/test/java/org/bricolages/streaming/event/FakeS3EventTest.java
+++ b/src/test/java/org/bricolages/streaming/event/FakeS3EventTest.java
@@ -1,0 +1,38 @@
+package org.bricolages.streaming.event;
+import org.bricolages.streaming.s3.S3ObjectMetadata;
+import java.time.Instant;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import lombok.*;
+
+public class FakeS3EventTest {
+    @Test
+    public void messageBody() throws Exception {
+        /*
+            % echo '{"Records":[{"eventVersion":"2.0","eventSource":"bricolage:preprocessor","eventTime":"2016-09-06T13:52:49Z","eventName":"ObjectCreated:Put","s3":{"s3SchemaVersion":"1.0","bucket":{"name":"test-bucket"},"object":{"key":"test-prefix/test-file.json.gz","size":"1358","eTag":"bfa868a9c00376f6704f41d6a9e0da20"}}}]}' | ruby -rjson -e 'puts JSON.pretty_generate(JSON.load($stdin.read))'
+            {
+              "Records": [
+                {
+                  "eventVersion": "2.0",
+                  "eventSource": "bricolage:preprocessor",
+                  "eventTime": "2016-09-06T13:52:49Z",
+                  "eventName": "ObjectCreated:Put",
+                  "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "bucket": {
+                      "name": "test-bucket"
+                    },
+                    "object": {
+                      "key": "test-prefix/test-file.json.gz",
+                      "size": "1358",
+                      "eTag": "bfa868a9c00376f6704f41d6a9e0da20"
+                    }
+                  }
+                }
+              ]
+            }
+        */
+        val e = new FakeS3Event(new S3ObjectMetadata("s3://test-bucket/test-prefix/test-file.json.gz", Instant.parse("2016-09-06T13:52:49Z"), 1358, "bfa868a9c00376f6704f41d6a9e0da20"));
+        assertEquals("{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"bricolage:preprocessor\",\"eventTime\":\"2016-09-06T13:52:49Z\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"s3SchemaVersion\":\"1.0\",\"bucket\":{\"name\":\"test-bucket\"},\"object\":{\"key\":\"test-prefix/test-file.json.gz\",\"size\":\"1358\",\"eTag\":\"bfa868a9c00376f6704f41d6a9e0da20\"}}}]}", e.messageBody());
+    }
+}

--- a/tools/send-s3-event.rb
+++ b/tools/send-s3-event.rb
@@ -3,7 +3,8 @@
 
 require 'yaml'
 
-config_path = ARGV[0] || 'config.yml'
+no_dispatch = ARGV.delete('--no-dispatch')
+config_path = ARGV.shift || 'config.yml'
 config = YAML.load(File.read(config_path))
 region = config['region']
 ENV['AWS_REGION'] = region
@@ -45,5 +46,6 @@ $stdin.each do |line|
       }
     }
   }
+  body["noDispatch"] = true if no_dispatch
   send_message.(body)
 end

--- a/tools/send-shutdown
+++ b/tools/send-shutdown
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [[ -z $1 ]]
+then
+    echo "Usage: $0 QUEUE_NAME" 2>&1
+    exit 1
+fi
+queue=$1
+
+exec aws sqs send-message --queue-url="https://sqs.ap-northeast-1.amazonaws.com/789035092620/$queue" --message-body='{"Records":[{"eventName":"shutdown"}]}'


### PR DESCRIPTION
S3にオブジェクトをPUTして自動でイベントを発生させるのではなく、自前でSQSにイベントを詰めるように変更。

自動でイベントが発生するように設定してしまうと選択の余地がなく、strloaderにイベントを渡さず前処理だけするということができないため。例えばテーブルの過去データを処理するときはすぐにロードするのではなく、前処理だけを行いたい。

### 注意点 

- テーブル定義の変更あり（preproc_log.dispatchedカラム追加）
