### PR TITLE
Use application.yml for app settings

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -13,3 +13,14 @@ spring:
 
 flyway:
     enabled: false
+
+bricolage:
+    event-queue:
+        url: ${bricolage.event.queue.url}
+    log-queue:
+        url: ${bricolage.log.queue.url}
+    mappings:
+        -
+          src: "s3://src-bucket/((.*)\\.gz)"
+          dest: "s3://dst-buckert/$1"
+          table: "$2"

--- a/config/streaming-preprocessor.yml.example
+++ b/config/streaming-preprocessor.yml.example
@@ -1,7 +1,0 @@
-queue:
-    url: https://sqs.ap-northeast-1.amazonaws.com/111111111111/QUEUE_NAME
-
-mapping:
-    -
-      src: "s3://SOURCE_BUFFER_NAME/PREFIX/(.*\\.gz)"
-      dest: "s3://DEST_BUFFER_NAME/PREFIX/$1"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+bricolage:
+    event-queue:
+        visibility-timeout: 120
+        max-number-of-messages: 10
+        wait-time-seconds: 0

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+bricolage:
+    event-queue:
+        visibility-timeout: 120
+        max-number-of-messages: 10
+        wait-time-seconds: 0


### PR DESCRIPTION
streaming-preprocessor.ymlを廃止して、application.ymlにすべての設定値を保持するようにします。

#### application.yml中での環境変数参照
`name: ${foo.bar}`と設定すると、`name`に`FOO_VAR`という環境変数が代入されます。

#### 環境毎に設定ファイルを切り替え
SpringのProfile機能を使います。
`config/application-development.yml`というファイルを用意した上で、`java -jar -Dspring.profiles.active=development bricolage-streaming-preprocessor.jar`のように起動すると、application.ymlに加えて、application-development.ymlの内容が読み込まれます。

また環境変数`SPRING_PROFILE_ACTIVE`でも指定可能。

設置値の記載場所は、以下のような方針に従うのがいいです。

- デフォルトの設定値: `src/(main|test)/resources/application.yml`
- 環境間で共通の設定値: `config/application.yml`
- 環境毎の設定値: `config/application-*.yml`
