### PR TITLE
Remove heading null chars to prevent load errors

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -41,7 +41,7 @@ class TextOp extends SingleColumnOp {
 
     @Override
     protected Object applyValue(Object value, Record record) throws FilterException {
-        String str = castStringForce(value);
+        String str = removeHeadNullChars(castStringForce(value));
         if (str == null) return null;
         if (maxByteLength > 0) {
             boolean overflow = (str.getBytes(DATA_FILE_CHARSET).length > maxByteLength);
@@ -64,5 +64,16 @@ class TextOp extends SingleColumnOp {
         if (value == null) return null;
         if (!(value instanceof String)) return null;
         return (String)value;
+    }
+
+    final Pattern nullCharsPattern = Pattern.compile("^\\x00+$");
+    String removeHeadNullChars(String str) {
+        if (str == null) return null;
+        // return if first char is not \0
+        if (0 != str.indexOf("\0")) return str;
+        // return null if all chars are \0
+        if (nullCharsPattern.matcher(str).matches()) return null;
+        // remove heading \0(s) if some chars follows
+        return str.replaceFirst("^\\x00+", "");
     }
 }

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -41,7 +41,7 @@ class TextOp extends SingleColumnOp {
 
     @Override
     protected Object applyValue(Object value, Record record) throws FilterException {
-        String str = removeHeadNullChars(castStringForce(value));
+        String str = dropIfHeadingNullChars(castStringForce(value));
         if (str == null) return null;
         if (maxByteLength > 0) {
             boolean overflow = (str.getBytes(DATA_FILE_CHARSET).length > maxByteLength);
@@ -66,14 +66,9 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    final Pattern nullCharsPattern = Pattern.compile("^\\x00+$");
-    String removeHeadNullChars(String str) {
+    String dropIfHeadingNullChars(String str) {
         if (str == null) return null;
-        // return if first char is not \0
-        if (0 != str.indexOf("\0")) return str;
-        // return null if all chars are \0
-        if (nullCharsPattern.matcher(str).matches()) return null;
-        // remove heading \0(s) if some chars follows
-        return str.replaceFirst("^\\x00+", "");
+        if (str.startsWith("\0")) return null;
+        return str;
     }
 }

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -66,7 +66,7 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    final private Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
+    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
 
     String removeAfterNullChar(String str) {
         if (str == null) return null;

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -41,7 +41,7 @@ class TextOp extends SingleColumnOp {
 
     @Override
     protected Object applyValue(Object value, Record record) throws FilterException {
-        String str = dropIfHeadingNullChars(castStringForce(value));
+        String str = removeAfterNullChar(castStringForce(value));
         if (str == null) return null;
         if (maxByteLength > 0) {
             boolean overflow = (str.getBytes(DATA_FILE_CHARSET).length > maxByteLength);
@@ -66,9 +66,11 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    String dropIfHeadingNullChars(String str) {
+    Pattern afterNullCharPattern = Pattern.compile("\\x00.*");
+
+    String removeAfterNullChar(String str) {
         if (str == null) return null;
-        if (str.startsWith("\0")) return null;
-        return str;
+        if (str.indexOf('\0') == -1) return str; // avoid regex when no null chars
+        return afterNullCharPattern.matcher(str).replaceFirst("");
     }
 }

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -66,11 +66,11 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    Pattern afterNullCharPattern = Pattern.compile("\\x00.*");
+    final private Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
 
     String removeAfterNullChar(String str) {
         if (str == null) return null;
         if (str.indexOf('\0') == -1) return str; // avoid regex when no null chars
-        return afterNullCharPattern.matcher(str).replaceFirst("");
+        return AFTER_NULL_CHAR_PATTERN.matcher(str).replaceFirst("");
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -40,6 +40,9 @@ public class TextOpTest {
         assertEquals("aaaa", f.applyValue("aaaa", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
+        assertNull(f.applyValue("\0\0\0\0\0", rec));
+        assertEquals(false, rec.get("text_col_overflow"));
+
         assertEquals("aaaaXX", f.applyValue("aaaaXX", rec));
         assertEquals(true, rec.get("text_col_overflow"));
     }
@@ -50,5 +53,15 @@ public class TextOpTest {
         assertEquals("00aa", f.applyValue("00aa", null));
         assertNull(f.applyValue("aaaa", null));
         assertNull(f.applyValue("00000", null));
+    }
+
+    @Test
+    public void apply_nothing() throws Exception {
+        val f = new TextOp(null, -1, false, false, null);
+        assertEquals("abcd\0", f.applyValue("abcd\0", null));
+        assertEquals("abcd", f.applyValue("\0abcd", null));
+        assertEquals("abcd", f.applyValue("\0\0abcd", null));
+        assertNull(f.applyValue("\0", null));
+        assertNull(f.applyValue("\0\0\0", null));
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -40,7 +40,7 @@ public class TextOpTest {
         assertEquals("aaaa", f.applyValue("aaaa", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
-        assertNull(f.applyValue("\0\0\0\0\0", rec));
+        assertEquals("", f.applyValue("\0\0\0\0\0", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
         assertEquals("aaaaXX", f.applyValue("aaaaXX", rec));
@@ -58,10 +58,9 @@ public class TextOpTest {
     @Test
     public void apply_nothing() throws Exception {
         val f = new TextOp(null, -1, false, false, null);
-        assertEquals("abcd\0", f.applyValue("abcd\0", null));
-        assertNull(f.applyValue("\0abcd", null));
-        assertNull(f.applyValue("\0\0abcd", null));
-        assertNull(f.applyValue("\0", null));
-        assertNull(f.applyValue("\0\0\0", null));
+        assertEquals("abcd", f.applyValue("abcd", null));
+        assertEquals("efgh", f.applyValue("efgh\0xxxx", null));
+        assertEquals("", f.applyValue("\0\0abcd", null));
+        assertEquals("", f.applyValue("\0\0\0", null));
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -59,8 +59,8 @@ public class TextOpTest {
     public void apply_nothing() throws Exception {
         val f = new TextOp(null, -1, false, false, null);
         assertEquals("abcd\0", f.applyValue("abcd\0", null));
-        assertEquals("abcd", f.applyValue("\0abcd", null));
-        assertEquals("abcd", f.applyValue("\0\0abcd", null));
+        assertNull(f.applyValue("\0abcd", null));
+        assertNull(f.applyValue("\0\0abcd", null));
         assertNull(f.applyValue("\0", null));
         assertNull(f.applyValue("\0\0\0", null));
     }


### PR DESCRIPTION
Change text operator to remove heading `\0` (null char) which cause load error with Redshift.

@aamine please review