### PR TITLE
Remove escaped unicode null string with text operator

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -67,7 +67,7 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("([^\\\\]|^)(\\\\\\\\)*(?=\\\\u0000)(\\\\u0000)");
+    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("([^\\\\]|^)(\\\\\\\\)*(\\\\u0000)");
 
     String removeAfterNullChar(String str) {
         if (str == null) return null;

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -1,6 +1,7 @@
 package org.bricolages.streaming.filter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.*;
 
@@ -66,11 +67,14 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\\\u0000.*");
+    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("([^\\\\]|^)(\\\\\\\\)*(?=\\\\u0000)(\\\\u0000)");
 
     String removeAfterNullChar(String str) {
         if (str == null) return null;
-        if (str.indexOf("\\u0000") == -1) return str; // avoid regex when no null chars
-        return AFTER_NULL_CHAR_PATTERN.matcher(str).replaceFirst("");
+        Matcher matcher = AFTER_NULL_CHAR_PATTERN.matcher(str);
+        if (matcher.find()) {
+            return str.substring(0, matcher.start(3));
+        }
+        return str;
     }
 }

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -66,11 +66,11 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
+    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\\\u0000.*");
 
     String removeAfterNullChar(String str) {
         if (str == null) return null;
-        if (str.indexOf('\0') == -1) return str; // avoid regex when no null chars
+        if (str.indexOf("\\u0000") == -1) return str; // avoid regex when no null chars
         return AFTER_NULL_CHAR_PATTERN.matcher(str).replaceFirst("");
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -62,7 +62,9 @@ public class TextOpTest {
         assertEquals("xyz", f.applyValue("xyz\\u0000abc", null));
         assertEquals("\\\\u0000", f.applyValue("\\\\u0000", null));
         assertEquals("\\\\\\\\u0000\\\\", f.applyValue("\\\\\\\\u0000\\\\\\u0000", null));
-        assertEquals("abc\\\\u0000", f.applyValue("abc\\\\u0000", null));
+        assertEquals("\\\\\\\\\\\\\\\\u0000\\\\", f.applyValue("\\\\\\\\\\\\\\\\u0000\\\\\\u0000", null));
+        assertEquals("abc\\\\\\\\u0000", f.applyValue("abc\\\\\\\\u0000", null));
+        assertEquals("abc\\\\\\\\", f.applyValue("abc\\\\\\\\\\u0000", null));
         assertEquals("abc\\\\u0000xyz", f.applyValue("abc\\\\u0000xyz\\u0000ijk", null));
         assertEquals("", f.applyValue("\\u0000abcd", null));
     }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -40,7 +40,7 @@ public class TextOpTest {
         assertEquals("aaaa", f.applyValue("aaaa", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
-        assertEquals("", f.applyValue("\0\0\0\0\0", rec));
+        assertEquals("", f.applyValue("\\u0000", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
         assertEquals("aaaaXX", f.applyValue("aaaaXX", rec));
@@ -59,8 +59,8 @@ public class TextOpTest {
     public void apply_nothing() throws Exception {
         val f = new TextOp(null, -1, false, false, null);
         assertEquals("abcd", f.applyValue("abcd", null));
-        assertEquals("efgh", f.applyValue("efgh\0xxxx", null));
-        assertEquals("", f.applyValue("\0\0abcd", null));
-        assertEquals("", f.applyValue("\0\0\0", null));
+        assertEquals("efgh", f.applyValue("efgh\\u0000", null));
+        assertEquals("", f.applyValue("\\u0000abcd", null));
+        assertEquals("", f.applyValue("\\u0000\\u0000\\u0000", null));
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -40,7 +40,7 @@ public class TextOpTest {
         assertEquals("aaaa", f.applyValue("aaaa", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
-        assertEquals("", f.applyValue("\\u0000", rec));
+        assertEquals("", f.applyValue("\\u0000\\u0000", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
         assertEquals("aaaaXX", f.applyValue("aaaaXX", rec));
@@ -58,9 +58,12 @@ public class TextOpTest {
     @Test
     public void apply_nothing() throws Exception {
         val f = new TextOp(null, -1, false, false, null);
-        assertEquals("abcd", f.applyValue("abcd", null));
-        assertEquals("efgh", f.applyValue("efgh\\u0000", null));
+        assertEquals("abc", f.applyValue("abc", null));
+        assertEquals("xyz", f.applyValue("xyz\\u0000abc", null));
+        assertEquals("\\\\u0000", f.applyValue("\\\\u0000", null));
+        assertEquals("\\\\\\\\u0000\\\\", f.applyValue("\\\\\\\\u0000\\\\\\u0000", null));
+        assertEquals("abc\\\\u0000", f.applyValue("abc\\\\u0000", null));
+        assertEquals("abc\\\\u0000xyz", f.applyValue("abc\\\\u0000xyz\\u0000ijk", null));
         assertEquals("", f.applyValue("\\u0000abcd", null));
-        assertEquals("", f.applyValue("\\u0000\\u0000\\u0000", null));
     }
 }


### PR DESCRIPTION
It was `\u0000` that I have to escape in PR https://github.com/aamine/bricolage-streaming-preprocessor/pull/17 . Not `\0`, the ascii nul char. Since control chars are escaped in JSON data.

@aamine please review