### PR TITLE
Add reject op

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ Aggregates rest columns except specified columns.
 
 - `rejectColumns`: Kept columns
 
+### `reject`: Reject Records Matched with Condition
+
+Reject records matched with condition described in params.
+
+#### `type`: `string`
+
+- `value`: If this value(string) and `target_columns` value are equal, the record will be rejected.
+
+#### `type`: `integer`
+
+- `value`: If this value(integer) and `target_columns` value are equal, the record will be rejected.
+
+#### `type`: `null`
+
+If `target_columns` value is null, it will reject the record.
+
 ## License
 
 MIT license. See LICENSE file for details.

--- a/src/main/java/org/bricolages/streaming/filter/Op.java
+++ b/src/main/java/org/bricolages/streaming/filter/Op.java
@@ -33,6 +33,7 @@ public abstract class Op {
         DeleteOp.register();
         RenameOp.register();
         CollectRestOp.register();
+        RejectOp.register();
     }
 
     static final public Op build(OperatorDefinition def) {

--- a/src/main/java/org/bricolages/streaming/filter/RejectOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/RejectOp.java
@@ -35,13 +35,12 @@ class RejectOp extends Op {
         }
     }
     static class NullParameters extends Parameters {
-        @Getter @Setter Boolean isNull;
         Function<Object, Boolean> getMatcher() {
-            return (target) -> (target == null) == isNull;
+            return (target) -> target == null;
         }
     }
 
-    private Function<Object, Boolean> matcher;
+    Function<Object, Boolean> matcher;
 
     RejectOp(OperatorDefinition def, Parameters params) {
         this(def, params.getMatcher());

--- a/src/main/java/org/bricolages/streaming/filter/RejectOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/RejectOp.java
@@ -1,0 +1,65 @@
+package org.bricolages.streaming.filter;
+
+import java.util.function.Function;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import lombok.*;
+
+class RejectOp extends Op {
+    static final void register() {
+        Op.registerOperator("reject", (def) ->
+            new RejectOp(def, def.mapParameters(Parameters.class))
+        );
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = StringPatameters.class, name = "string"),
+        @JsonSubTypes.Type(value = IntegerParameters.class, name = "integer"),
+        @JsonSubTypes.Type(value = NullParameters.class, name = "null") 
+    })
+    abstract static class Parameters {
+        abstract Function<Object, Boolean> getMatcher();
+    }
+    static class StringPatameters extends Parameters {
+        @Getter @Setter String value;
+        Function<Object, Boolean> getMatcher() {
+            return (target) -> value.equals(target);
+        }
+    }
+    static class IntegerParameters extends Parameters {
+        @Getter @Setter Integer value;
+        Function<Object, Boolean> getMatcher() {
+            return (target) -> value.equals(target);
+        }
+    }
+    static class NullParameters extends Parameters {
+        @Getter @Setter Boolean isNull;
+        Function<Object, Boolean> getMatcher() {
+            return (target) -> (target == null) == isNull;
+        }
+    }
+
+    private Function<Object, Boolean> matcher;
+
+    RejectOp(OperatorDefinition def, Parameters params) {
+        this(def, params.getMatcher());
+    }
+
+    RejectOp(OperatorDefinition def, Function<Object, Boolean> matcher) {
+        super(def);
+        this.matcher = matcher;
+    }
+
+    @Override
+    public Record apply(Record record) {
+        String targetColumn = getColumnName();
+        Object targetValue = record.get(targetColumn);
+        if (matcher.apply(targetValue)) {
+            return null;
+        }
+        
+        return record;
+    }
+}

--- a/src/test/java/org/bricolages/streaming/filter/RejectOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/RejectOpTest.java
@@ -42,34 +42,16 @@ public class RejectOpTest {
 
     @Test
     public void apply_matched_null() throws Exception {
-        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": true}");
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\"}");
         val op = (RejectOp)Op.build(def);
         val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}");
-        val out = op.apply(rec);
-        assertEquals(null, out);
-    }
-
-    @Test
-    public void apply_not_matched_null() throws Exception {
-        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": false}");
-        val op = (RejectOp)Op.build(def);
-        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}");
-        val out = op.apply(rec);
-        assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}", out.serialize());
-    }
-
-    @Test
-    public void apply_matched_non_null() throws Exception {
-        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": false}");
-        val op = (RejectOp)Op.build(def);
-        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"non_null\"}");
         val out = op.apply(rec);
         assertEquals(null, out);
     }
 
     @Test
     public void apply_not_matched_non_null() throws Exception {
-        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": true}");
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\"}");
         val op = (RejectOp)Op.build(def);
         val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"non_null\"}");
         val out = op.apply(rec);

--- a/src/test/java/org/bricolages/streaming/filter/RejectOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/RejectOpTest.java
@@ -1,0 +1,78 @@
+package org.bricolages.streaming.filter;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import lombok.*;
+
+public class RejectOpTest {
+    @Test
+    public void apply_matched_string() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"string\", \"value\": \"str\"}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"str\"}");
+        val out = op.apply(rec);
+        assertEquals(null, out);
+    }
+
+    @Test
+    public void apply_not_matched_string() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"string\", \"value\": \"not_matched\"}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"str\"}");
+        val out = op.apply(rec);
+        assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"str\"}", out.serialize());
+    }
+
+    @Test
+    public void apply_matched_integer() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"integer\", \"value\": 1}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":1}");
+        val out = op.apply(rec);
+        assertEquals(null, out);
+    }
+
+    @Test
+    public void apply_not_matched_integer() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"integer\", \"value\": 2}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":1}");
+        val out = op.apply(rec);
+        assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":1}", out.serialize());
+    }
+
+    @Test
+    public void apply_matched_null() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": true}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}");
+        val out = op.apply(rec);
+        assertEquals(null, out);
+    }
+
+    @Test
+    public void apply_not_matched_null() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": false}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}");
+        val out = op.apply(rec);
+        assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":null}", out.serialize());
+    }
+
+    @Test
+    public void apply_matched_non_null() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": false}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"non_null\"}");
+        val out = op.apply(rec);
+        assertEquals(null, out);
+    }
+
+    @Test
+    public void apply_not_matched_non_null() throws Exception {
+        val def = new OperatorDefinition("reject", "schema.table", "hoge", "{\"type\": \"null\", \"isNull\": true}");
+        val op = (RejectOp)Op.build(def);
+        val rec = Record.parse("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"non_null\"}");
+        val out = op.apply(rec);
+        assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"hoge\":\"non_null\"}", out.serialize());
+    }
+}


### PR DESCRIPTION
条件で行を落とす Op を実装しました。

`target_column` で比較対象のカラムを指定し、比較の条件を `params` で指定します。`params` は `type` プロパティを含み、`type` プロパティの値によって比較の型や条件の指定方法が異なります。`type` の値とその条件の意味の対応を以下に示します。

`type` の値 | 追加で必要な `params` のプロパティ| 条件の意味 |
|:-----------|:------------------------------------|:-----------|
|`"string"`   | `value`                                               | 対象のカラムの値(文字列)が `params.value` と等しいとき、行を落とす|
|`"integer"` | `value`                                               | 対象のカラムの値(整数値)が `params.value` と等しいとき、行を落とす|
|`"null"`       | `isNull`                                               | 対象のカラムの値が `null` であるかどうかが `params.isNull` と等しいとき、行を落とす|

`isNull` とかつけずに `reject` では `null` を落とすだけにし、別で落とす条件を反転させた `select` Op を作ったほうがいいのかもしれません。
(そのほうが `string` や `integer` と整合性が取れる)