### PR TITLE
Revert "Remove escaped unicode null string with text operator"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Jul 14 16:52:54 JST 2016
+#Tue Jan 31 16:06:22 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -66,11 +66,13 @@ class TextOp extends SingleColumnOp {
         return (String)value;
     }
 
-    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
-
     String removeAfterNullChar(String str) {
         if (str == null) return null;
-        if (str.indexOf('\0') == -1) return str; // avoid regex when no null chars
-        return AFTER_NULL_CHAR_PATTERN.matcher(str).replaceFirst("");
+        int idx = str.indexOf('\0');
+        if (idx == -1) {
+            return str;
+        } else {
+            return str.substring(0,idx);
+        }
     }
 }

--- a/src/main/java/org/bricolages/streaming/filter/TextOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/TextOp.java
@@ -41,7 +41,7 @@ class TextOp extends SingleColumnOp {
 
     @Override
     protected Object applyValue(Object value, Record record) throws FilterException {
-        String str = removeAfterNull(castStringForce(value));
+        String str = removeAfterNullChar(castStringForce(value));
         if (str == null) return null;
         if (maxByteLength > 0) {
             boolean overflow = (str.getBytes(DATA_FILE_CHARSET).length > maxByteLength);
@@ -65,18 +65,12 @@ class TextOp extends SingleColumnOp {
         if (!(value instanceof String)) return null;
         return (String)value;
     }
-    String removeAfterNull(String str) {
+
+    static final Pattern AFTER_NULL_CHAR_PATTERN = Pattern.compile("\\x00.*");
+
+    String removeAfterNullChar(String str) {
         if (str == null) return null;
-        int idx = 0;
-        while (idx < str.length()) {
-            idx = str.indexOf('\\', idx);
-            if (idx < 0) break;
-            if (str.substring(idx, idx + 6).equals("\\u0000")) {
-                // Drop rest characters
-                return str.substring(0, idx);
-            }
-            idx += 2;  // skip any character after '\'
-        }
-        return str;
+        if (str.indexOf('\0') == -1) return str; // avoid regex when no null chars
+        return AFTER_NULL_CHAR_PATTERN.matcher(str).replaceFirst("");
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -40,7 +40,7 @@ public class TextOpTest {
         assertEquals("aaaa", f.applyValue("aaaa", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
-        assertEquals("", f.applyValue("\\u0000\\u0000", rec));
+        assertEquals("", f.applyValue("\0\0\0\0\0", rec));
         assertEquals(false, rec.get("text_col_overflow"));
 
         assertEquals("aaaaXX", f.applyValue("aaaaXX", rec));
@@ -58,14 +58,9 @@ public class TextOpTest {
     @Test
     public void apply_nothing() throws Exception {
         val f = new TextOp(null, -1, false, false, null);
-        assertEquals("abc", f.applyValue("abc", null));
-        assertEquals("xyz", f.applyValue("xyz\\u0000abc", null));
-        assertEquals("\\\\u0000", f.applyValue("\\\\u0000", null));
-        assertEquals("\\\\\\\\u0000\\\\", f.applyValue("\\\\\\\\u0000\\\\\\u0000", null));
-        assertEquals("\\\\\\\\\\\\\\\\u0000\\\\", f.applyValue("\\\\\\\\\\\\\\\\u0000\\\\\\u0000", null));
-        assertEquals("abc\\\\\\\\u0000", f.applyValue("abc\\\\\\\\u0000", null));
-        assertEquals("abc\\\\\\\\", f.applyValue("abc\\\\\\\\\\u0000", null));
-        assertEquals("abc\\\\u0000xyz", f.applyValue("abc\\\\u0000xyz\\u0000ijk", null));
-        assertEquals("", f.applyValue("\\u0000abcd", null));
+        assertEquals("abcd", f.applyValue("abcd", null));
+        assertEquals("efgh", f.applyValue("efgh\0xxxx", null));
+        assertEquals("", f.applyValue("\0\0abcd", null));
+        assertEquals("", f.applyValue("\0\0\0", null));
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TextOpTest.java
@@ -60,7 +60,7 @@ public class TextOpTest {
         val f = new TextOp(null, -1, false, false, null);
         assertEquals("abcd", f.applyValue("abcd", null));
         assertEquals("efgh", f.applyValue("efgh\0xxxx", null));
-        assertEquals("", f.applyValue("\0\0abcd", null));
+        assertEquals("", f.applyValue("\0abcd", null));
         assertEquals("", f.applyValue("\0\0\0", null));
     }
 }


### PR DESCRIPTION
Reverts aamine/bricolage-streaming-preprocessor#18

対応する必要があるのは、`\u0000`ではなく、`\0`（ASCIIヌル文字）だった。