### PR TITLE
Throw ApplicationException instead of FilterException when sequence counter is starved

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
@@ -25,10 +25,10 @@ class SequenceOp extends SingleColumnOp {
         this.upperValue = seq.getNextValue();
     }
 
-    private long getNextValue() throws FilterException {
+    private long getNextValue() {
         currentValue ++;
         if (currentValue > upperValue) {
-            throw new FilterException("sequence number is starved");
+            throw new ApplicationError("sequence number is starved");
         }
         return currentValue;
     }

--- a/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
@@ -1,4 +1,6 @@
 package org.bricolages.streaming.filter;
+
+import org.bricolages.streaming.ApplicationError;
 import org.bricolages.streaming.SequencialNumberRepository;
 import lombok.*;
 

--- a/src/test/java/org/bricolages/streaming/filter/SequenceOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/SequenceOpTest.java
@@ -1,5 +1,6 @@
 package org.bricolages.streaming.filter;
 import org.junit.Test;
+import org.bricolages.streaming.ApplicationError;
 import static org.junit.Assert.*;
 import lombok.*;
 
@@ -29,7 +30,7 @@ public class SequenceOpTest {
         assertEquals("{\"a\":1,\"b\":2,\"c\":3,\"seq\":11}", out2.serialize());
     }
 
-    @Test(expected=FilterException.class)
+    @Test(expected=ApplicationError.class)
     public void apply_over_capacity() throws Exception {
         val def = new OperatorDefinition("sequence", "schema.table", "seq", "{}");
         val op = new SequenceOp(def);


### PR DESCRIPTION
https://github.com/aamine/bricolage-streaming-preprocessor/pull/24#issuecomment-276595519 のとおりです。
カラムを落としたまま完走するよりは例外で死んだほうがいいと思うのでとりあえず該当コミットを Revert します。
よりよい例外のハンドリングを考えたいです。