### PR TITLE
Add no_dispatch flag for tables

### DIFF
--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -212,7 +212,7 @@ public class Preprocessor implements EventHandlers {
             log.debug("src: {}, dest: {}, in: {}, out: {}", src.urlString(), dest.urlString(), result.inputRows, result.outputRows);
             result.succeeded();
             repos.save(result);
-            if (!event.doesNotDispatch()) {
+            if (!event.doesNotDispatch() && !params.doesNotDispatch()) {
                 logQueue.send(new FakeS3Event(obj));
                 result.dispatched();
                 repos.save(result);

--- a/src/main/java/org/bricolages/streaming/TableParams.java
+++ b/src/main/java/org/bricolages/streaming/TableParams.java
@@ -24,6 +24,9 @@ class TableParams {
     @Column(name="discard")
     boolean discard;
 
+    @Column(name="no_dispatch")
+    boolean no_dispatch;
+
     public TableParams(TableId id) {
         this.tableId = id.toString();
     }
@@ -34,5 +37,9 @@ class TableParams {
 
     public boolean doesDiscard() {
         return this.discard;
+    }
+
+    public boolean doesNotDispatch() {
+        return this.no_dispatch;
     }
 }


### PR DESCRIPTION
テーブル毎にStrloadへイベントを飛ばすかどうかを設定出来るようにします。

Preprocはしたいが、Strloadでロードはしたくない場合に利用します。
現状でも、Srloadでテーブルの設定をdisabledにすると上記の目的を達成出来ますが、Strloadの管理テーブルにロードされないオブジェクトのレコードがたまり続けるため、時間が経つとStrloadの管理SQLの性能が劣化します。そもそも、PreprocからStrloadへイベントを飛ばさないようにすることで、性能の劣化を回避しつつ、Preprocのみを実行出来るようにします。