### PR TITLE
Use MultilineDecription annotation

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -4,7 +4,7 @@
 - `filter`: `List`
 
 ## `integer` domain
-Integral number
+32bit signed integral number
 
 No parameters.
 
@@ -16,6 +16,8 @@ Timestamp converted from unix time
 
 ## `log_time` domain
 Timestamp indicating when log was recorded
+
+Usually this column becomes sortkey.
 
 - `sourceOffset`: `String`
   - Expected source data timezone, given by the string like '+00:00'
@@ -38,12 +40,12 @@ Boolean
 No parameters.
 
 ## `bigint` domain
-Big integral number
+64bit signed integral number
 
 No parameters.
 
 ## `float` domain
-Floating point number
+64bit floating point number
 
 No parameters.
 

--- a/src/main/java/org/bricolages/streaming/preflight/ReferenceGenerator.java
+++ b/src/main/java/org/bricolages/streaming/preflight/ReferenceGenerator.java
@@ -3,11 +3,11 @@ package org.bricolages.streaming.preflight;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
@@ -24,9 +24,10 @@ public class ReferenceGenerator {
             if (typeNameAnno == null) { continue; }
 
             docBuilder.append("## `" + typeNameAnno.value() + "` domain\n");
-            val classDescAnno = clazz.getAnnotation(JsonClassDescription.class);
+            val classDescAnno = clazz.getAnnotation(MultilineDescription.class);
             if (classDescAnno != null) {
-                docBuilder.append(classDescAnno.value() + "\n\n");
+                val classDesc = String.join("\n\n", classDescAnno.value());
+                docBuilder.append(classDesc + "\n\n");
             }
             val fields = Arrays.stream(clazz.getDeclaredFields()).
                 filter(field -> field.getAnnotation(JsonProperty.class) != null).
@@ -39,9 +40,10 @@ public class ReferenceGenerator {
             for (val field: fields) {
                 val fieldTypeName = field.getType().getSimpleName();
                 docBuilder.append("- `" + field.getName() + "`: `" + fieldTypeName + "`\n");
-                val fieldDescAnno = field.getAnnotation(JsonPropertyDescription.class);
+                val fieldDescAnno = field.getAnnotation(MultilineDescription.class);
                 if (fieldDescAnno != null) {
-                    docBuilder.append("  - " + fieldDescAnno.value() + "\n");
+                    val fieldDesc = String.join("\n\n", fieldDescAnno.value());
+                    docBuilder.append("  - " + fieldDesc + "\n");
                 }
             }
             docBuilder.append("\n");
@@ -51,5 +53,10 @@ public class ReferenceGenerator {
         try (val os = new FileOutputStream(file)) {
             os.write(docBuilder.toString().getBytes());
         }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public static @interface MultilineDescription {
+        String[] value();
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/BigintDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/BigintDomain.java
@@ -6,13 +6,13 @@ import java.util.List;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("bigint")
-@JsonClassDescription("64bit signed integral number")
+@MultilineDescription("64bit signed integral number")
 public class BigintDomain implements ColumnParametersEntry {
     @Getter private final String type = "bigint";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.LZO;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/BooleanDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/BooleanDomain.java
@@ -5,13 +5,13 @@ import java.util.List;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("boolean")
-@JsonClassDescription("Boolean")
+@MultilineDescription("Boolean")
 public class BooleanDomain implements ColumnParametersEntry {
     @Getter private final String type = "boolean";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.RAW;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
@@ -6,22 +6,21 @@ import org.bricolages.streaming.filter.TimeZoneOp;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("date")
-@JsonClassDescription("Date time")
+@MultilineDescription("Date time")
 public class DateDomain implements ColumnParametersEntry {
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Expected source data timezone, given by the string like '+00:00'")
+    @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
     private String sourceOffset;
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Target timezone, given by the string like '+09:00'")
+    @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String targetOffset;
 
     @Getter private final String type = "timestamp";

--- a/src/main/java/org/bricolages/streaming/preflight/domains/FloatDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/FloatDomain.java
@@ -6,13 +6,13 @@ import java.util.List;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("float")
-@JsonClassDescription("64bit floating point number")
+@MultilineDescription("64bit floating point number")
 public class FloatDomain implements ColumnParametersEntry {
     @Getter private final String type = "float";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.LZO;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/IntegerDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/IntegerDomain.java
@@ -6,13 +6,13 @@ import java.util.List;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("integer")
-@JsonClassDescription("32bit signed integral number")
+@MultilineDescription("32bit signed integral number")
 public class IntegerDomain implements ColumnParametersEntry {
     @Getter private final String type = "integer";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.LZO;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
@@ -7,26 +7,28 @@ import org.bricolages.streaming.filter.TimeZoneOp;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("log_time")
-@JsonClassDescription("Timestamp indicating when log was recorded\n\nUsually this column becomes sortkey.")
+@MultilineDescription({
+    "Timestamp indicating when log was recorded",
+    "Usually this column becomes sortkey.",
+})
 public class LogTimeDomain implements ColumnParametersEntry {
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Expected source data timezone, given by the string like '+00:00'")
+    @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
     private String sourceOffset;
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Target timezone, given by the string like '+09:00'")
+    @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String targetOffset;
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Column name which is renamed from")
+    @MultilineDescription("Column name which is renamed from")
     private String sourceColumn;
 
     @Getter private final String type = "timestamp";

--- a/src/main/java/org/bricolages/streaming/preflight/domains/StringDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/StringDomain.java
@@ -5,20 +5,22 @@ import java.util.List;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("string")
-@JsonClassDescription("Text\n\nThis provides a shorthand such as `!string [bytes]`")
+@MultilineDescription({
+    "Text",
+    "This provides a shorthand such as `!string [bytes]`",
+})
 @NoArgsConstructor
 public class StringDomain implements ColumnParametersEntry {
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Declares max byte length")
+    @MultilineDescription("Declares max byte length")
     private int bytes;
 
     public String getType() {

--- a/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
@@ -6,18 +6,17 @@ import org.bricolages.streaming.filter.UnixTimeOp;
 import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
-import com.fasterxml.jackson.annotation.JsonClassDescription;
+import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("unixtime")
-@JsonClassDescription("Timestamp converted from unix time")
+@MultilineDescription("Timestamp converted from unix time")
 public class UnixtimeDomain implements ColumnParametersEntry {
     @Getter
     @JsonProperty(required = true)
-    @JsonPropertyDescription("Target timezone, given by the string like '+09:00'")
+    @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String zoneOffset;
 
     @Getter private final String type = "timestamp";


### PR DESCRIPTION
複数行のドキュメントを書きやすくするため、Jackson のアノテーションをやめて自前のアノテーションを使います。