### PR TITLE
Impl domain parameter default value configuration

### DIFF
--- a/config/preflight.yml.example
+++ b/config/preflight.yml.example
@@ -1,0 +1,3 @@
+default_values:
+  log_time: !log_time
+    target_offset: '+09:00'

--- a/src/main/java/org/bricolages/streaming/Config.java
+++ b/src/main/java/org/bricolages/streaming/Config.java
@@ -3,6 +3,7 @@ package org.bricolages.streaming;
 import lombok.Getter;
 import lombok.Setter;
 
+import org.bricolages.streaming.preflight.domains.DomainDefaultValues;
 import org.bricolages.streaming.s3.ObjectMapper;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -40,4 +41,7 @@ public class Config {
     @Getter
     @Setter
     private String destDs;
+    @Getter
+    @Setter
+    private DomainDefaultValues defaults;
 }

--- a/src/main/java/org/bricolages/streaming/preflight/ColumnParametersEntry.java
+++ b/src/main/java/org/bricolages/streaming/preflight/ColumnParametersEntry.java
@@ -23,4 +23,8 @@ public interface ColumnParametersEntry {
     ColumnEncoding getEncoding();
 
     List<OperatorDefinitionEntry> getOperatorDefinitionEntries(String columnName);
+
+    default void applyDefault(DomainDefaultValues defaultValues) {
+        return; // NOOP
+    };
 }

--- a/src/main/java/org/bricolages/streaming/preflight/CustomColumnParametersEntry.java
+++ b/src/main/java/org/bricolages/streaming/preflight/CustomColumnParametersEntry.java
@@ -2,7 +2,6 @@ package org.bricolages.streaming.preflight;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;

--- a/src/main/java/org/bricolages/streaming/preflight/PreflightConfig.java
+++ b/src/main/java/org/bricolages/streaming/preflight/PreflightConfig.java
@@ -2,28 +2,21 @@ package org.bricolages.streaming.preflight;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.List;
 import org.bricolages.streaming.preflight.domains.DomainDefaultValues;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import lombok.*;
 
-class StreamDefinitionEntry {
-    @Getter private List<ColumnDefinitionEntry> columns;
+public class PreflightConfig {
+    @Getter private DomainDefaultValues defaultValues;
 
-    static StreamDefinitionEntry load(Reader yamlSource) throws IOException {
+    public static PreflightConfig load(Reader yamlSource) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
             .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
             .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
-        return mapper.readValue(yamlSource, StreamDefinitionEntry.class);
-    }
-
-    public void applyDefaultValues(DomainDefaultValues defaultValues) {
-        if (defaultValues == null) { return; }
-        for (val column: columns) {
-            column.getParams().applyDefault(defaultValues);
-        }
+        return mapper.readValue(yamlSource, PreflightConfig.class);
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
@@ -7,7 +7,6 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
@@ -15,11 +14,9 @@ import lombok.*;
 @MultilineDescription("Date time")
 public class DateDomain implements ColumnParametersEntry {
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
     private String sourceOffset;
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String targetOffset;
 
@@ -33,5 +30,12 @@ public class DateDomain implements ColumnParametersEntry {
         val list = new ArrayList<OperatorDefinitionEntry>();
         list.add(new OperatorDefinitionEntry("timezone", columnName, tzParams));
         return list;
+    }
+
+    public void applyDefault(DomainDefaultValues defaultValues) {
+        val defaultValue = defaultValues.getDate();
+        if (defaultValue == null) { return; }
+        this.sourceOffset = this.sourceOffset == null ? defaultValue.sourceOffset : this.sourceOffset;
+        this.targetOffset = this.targetOffset == null ? defaultValue.targetOffset : this.targetOffset;
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DomainDefaultValues.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DomainDefaultValues.java
@@ -1,0 +1,21 @@
+package org.bricolages.streaming.preflight.domains;
+
+import java.io.IOException;
+import java.io.Reader;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import lombok.*;
+
+public class DomainDefaultValues {
+    @Getter
+    private DateDomain date;
+    @Getter
+    private LogTimeDomain logTime;
+    @Getter
+    private StringDomain string;
+    @Getter
+    private UnixtimeDomain unixtime;
+}

--- a/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
@@ -8,7 +8,6 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
@@ -19,15 +18,12 @@ import lombok.*;
 })
 public class LogTimeDomain implements ColumnParametersEntry {
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
     private String sourceOffset;
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String targetOffset;
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Column name which is renamed from")
     private String sourceColumn;
 
@@ -45,5 +41,13 @@ public class LogTimeDomain implements ColumnParametersEntry {
         list.add(new OperatorDefinitionEntry("timezone", sourceColumn, tzParams));
         list.add(new OperatorDefinitionEntry("rename", sourceColumn, renameParams));
         return list;
+    }
+
+    public void applyDefault(DomainDefaultValues defaultValues) {
+        val defaultValue = defaultValues.getLogTime();
+        if (defaultValue == null) { return; }
+        this.sourceOffset = this.sourceOffset == null ? defaultValue.sourceOffset : this.sourceOffset;
+        this.targetOffset = this.targetOffset == null ? defaultValue.targetOffset : this.targetOffset;
+        this.sourceColumn = this.sourceColumn == null ? defaultValue.sourceColumn : this.sourceColumn;
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/StringDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/StringDomain.java
@@ -7,7 +7,6 @@ import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
@@ -19,9 +18,8 @@ import lombok.*;
 @NoArgsConstructor
 public class StringDomain implements ColumnParametersEntry {
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Declares max byte length")
-    private int bytes;
+    private Integer bytes;
 
     public String getType() {
         return String.format("varchar(%d)", bytes);
@@ -36,5 +34,11 @@ public class StringDomain implements ColumnParametersEntry {
     @JsonCreator
     public StringDomain(String bytes) {
         this.bytes = Integer.valueOf(bytes);
+    }
+
+    public void applyDefault(DomainDefaultValues defaultValues) {
+        val defaultValue = defaultValues.getString();
+        if (defaultValue == null) { return; }
+        this.bytes = this.bytes == null ? defaultValue.bytes : this.bytes;
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
@@ -7,7 +7,6 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
@@ -15,7 +14,6 @@ import lombok.*;
 @MultilineDescription("Timestamp converted from unix time")
 public class UnixtimeDomain implements ColumnParametersEntry {
     @Getter
-    @JsonProperty(required = true)
     @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String zoneOffset;
 
@@ -28,5 +26,11 @@ public class UnixtimeDomain implements ColumnParametersEntry {
         val list = new ArrayList<OperatorDefinitionEntry>();
         list.add(new OperatorDefinitionEntry("unixtime", columnName, utParams));
         return list;
+    }
+
+    public void applyDefault(DomainDefaultValues defaultValues) {
+        val defaultValue = defaultValues.getUnixtime();
+        if (defaultValue == null) { return; }
+        this.zoneOffset = this.zoneOffset == null ? defaultValue.zoneOffset : this.zoneOffset;
     }
 }


### PR DESCRIPTION
ドメインのパラメータにデフォルト値を設定できるようにしてみました。
しかし、実装も使い勝手もイマイチで、釈然としません……

イマイチポイント:
- `applyDefault` メソッドの実装が冗長
- `DomainDefaultValues` クラスの定義が冗長
- `preflight.yml` の記述がイマイチ
  - キーがドメイン名になっているにもかかわらず、Jackson の仕様で `!ドメイン名` も必要で冗長
