### PR TITLE
Support local file as input data

### DIFF
--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -39,8 +39,8 @@ public class Application {
 
     public void run(String[] args) throws Exception {
         boolean oneshot = false;
-        S3ObjectLocation mapUrl = null;
-        S3ObjectLocation procUrl = null;
+        SourceLocator mapUrl = null;
+        SourceLocator procUrl = null;
         String streamDefFilename = null;
         String schemaName = null;
         String tableName = null;
@@ -80,7 +80,7 @@ public class Application {
                     System.err.println("missing argument for --map-url");
                     System.exit(1);
                 }
-                mapUrl = S3ObjectLocation.forUrl(kv[1]);
+                mapUrl = locatorFactory().parse(kv[1]);
             }
             else if (args[i].startsWith("--process-url=")) {
                 val kv = args[i].split("=", 2);
@@ -88,7 +88,7 @@ public class Application {
                     System.err.println("missing argument for --process-url");
                     System.exit(1);
                 }
-                procUrl = S3ObjectLocation.forUrl(kv[1]);
+                procUrl = locatorFactory().parse(kv[1]);
             }
             else if (Objects.equals(args[i], "--domains-reference")) {
                 domainsReference = true;
@@ -112,7 +112,7 @@ public class Application {
         }
 
         if (mapUrl != null) {
-            val result = mapper().map(mapUrl);
+            val result = mapper().map(mapUrl.toString());
             System.out.println(result.getDestLocation());
             System.exit(0);
         }
@@ -217,5 +217,10 @@ public class Application {
     @Bean
     public OpBuilder opBuilder() {
         return new OpBuilder(sequentialNumberRepository);
+    }
+
+    @Bean
+    public LocatorFactory locatorFactory() {
+        return new LocatorFactory(s3());
     }
 }

--- a/src/main/java/org/bricolages/streaming/LocalFileSourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/LocalFileSourceLocator.java
@@ -1,0 +1,28 @@
+package org.bricolages.streaming;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import lombok.*;
+
+public class LocalFileSourceLocator implements SourceLocator {
+    private final String fileUrl;
+
+    LocalFileSourceLocator(String filepath) throws IOException {
+        // /path/to/file -> file:/path/to/file
+        // ./relative/file -> file:/path/to/relative/file
+        this.fileUrl = new File(filepath).getCanonicalFile().toURI().toString();
+    }
+
+    public BufferedReader open() throws IOException {
+        val filereader = new FileReader(fileUrl);
+		return new BufferedReader(filereader);
+    }
+
+    public String toString() {
+        return this.fileUrl;
+    }
+}

--- a/src/main/java/org/bricolages/streaming/LocalFileSourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/LocalFileSourceLocator.java
@@ -2,27 +2,40 @@ package org.bricolages.streaming;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URI;
 import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
 
 import lombok.*;
 
 public class LocalFileSourceLocator implements SourceLocator {
-    private final String fileUrl;
+    private final URI fileUrl;
 
     LocalFileSourceLocator(String filepath) throws IOException {
         // /path/to/file -> file:/path/to/file
         // ./relative/file -> file:/path/to/relative/file
-        this.fileUrl = new File(filepath).getCanonicalFile().toURI().toString();
+        this.fileUrl = new File(filepath).getCanonicalFile().toURI();
     }
 
     public BufferedReader open() throws IOException {
-        val filereader = new FileReader(fileUrl);
-		return new BufferedReader(filereader);
+        val inputStream = new FileInputStream(fileUrl.getPath());
+        if (isGzip()) {
+            return new BufferedReader(new InputStreamReader(new GZIPInputStream(inputStream)));
+        } else {
+            return new BufferedReader(new InputStreamReader(inputStream));
+        }
+    }
+
+    private boolean isGzip() {
+        return fileUrl.toString().endsWith(".gz");
     }
 
     public String toString() {
-        return this.fileUrl;
+        return this.fileUrl.toString();
     }
 }

--- a/src/main/java/org/bricolages/streaming/LocatorFactory.java
+++ b/src/main/java/org/bricolages/streaming/LocatorFactory.java
@@ -16,6 +16,7 @@ public class LocatorFactory {
         val uri = new URI(urlString);
         val scheme = uri.getScheme();
         if (scheme == null) {
+            // eg. "./relatice/path/to/file.gz"
             return new LocalFileSourceLocator(urlString);
         } else if (scheme.equals("file")) {
             return new LocalFileSourceLocator(uri.getPath());

--- a/src/main/java/org/bricolages/streaming/LocatorFactory.java
+++ b/src/main/java/org/bricolages/streaming/LocatorFactory.java
@@ -1,0 +1,35 @@
+package org.bricolages.streaming;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.bricolages.streaming.s3.S3Agent;
+import org.bricolages.streaming.s3.S3ObjectLocation;
+
+import lombok.*;
+
+@RequiredArgsConstructor
+public class LocatorFactory {
+    final S3Agent s3agent;
+
+    SourceLocator parse(String urlString) throws URISyntaxException, IOException {
+        val uri = new URI(urlString);
+        val scheme = uri.getScheme();
+        if (scheme == null) {
+            return new LocalFileSourceLocator(urlString);
+        } else if (scheme.equals("file")) {
+            return new LocalFileSourceLocator(uri.getPath());
+        } else if (scheme.equals("s3")) {
+            return new S3ObjectSourceLocator(s3agent, new S3ObjectLocation(uri.getHost(), uri.getPath()));
+        }
+        throw new UnsupportedSchemeException("Unsupported scheme: " + scheme);
+    }
+
+    public static class UnsupportedSchemeException extends ApplicationError {
+        static final long serialVersionUID = 1L;
+        
+        UnsupportedSchemeException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/bricolages/streaming/S3ObjectSourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/S3ObjectSourceLocator.java
@@ -1,0 +1,30 @@
+package org.bricolages.streaming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import org.bricolages.streaming.s3.S3Agent;
+import org.bricolages.streaming.s3.S3IOException;
+import org.bricolages.streaming.s3.S3ObjectLocation;
+
+public class S3ObjectSourceLocator implements SourceLocator {
+    private final S3Agent agent;
+    private final S3ObjectLocation location;
+
+    S3ObjectSourceLocator(S3Agent agent, S3ObjectLocation location) {
+        this.agent = agent;
+        this.location = location;
+    }
+
+    public BufferedReader open() throws IOException {
+        try {
+            return agent.openBufferedReader(location);
+        } catch (S3IOException ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    public String toString() {
+        return location.toString();
+    }
+}

--- a/src/main/java/org/bricolages/streaming/SourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/SourceLocator.java
@@ -1,0 +1,10 @@
+package org.bricolages.streaming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+public interface SourceLocator {
+    BufferedReader open() throws IOException;
+
+    String toString();
+}

--- a/src/main/java/org/bricolages/streaming/preflight/Runner.java
+++ b/src/main/java/org/bricolages/streaming/preflight/Runner.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.apache.commons.io.FilenameUtils;
 import org.bricolages.streaming.Config;
 import org.bricolages.streaming.Preprocessor;
+import org.bricolages.streaming.SourceLocator;
 import org.bricolages.streaming.filter.FilterResult;
 import org.bricolages.streaming.filter.ObjectFilterFactory;
 import org.bricolages.streaming.filter.OperatorDefinition;
@@ -87,7 +88,7 @@ public class Runner {
         }
     }
 
-    public void run(String streamDefFilename, S3ObjectLocation src, String schemaName, String tableName) throws IOException, S3IOException {
+    public void run(String streamDefFilename, SourceLocator src, String schemaName, String tableName) throws IOException, S3IOException {
         val preflightConfig = loadPreflightConfig("config/preflight.yml");
         val fullTableName = schemaName + "." + tableName;
         val streamDefFile = new StreamDefinitionFile(streamDefFilename);
@@ -95,14 +96,14 @@ public class Runner {
         streamDef.applyDefaultValues(preflightConfig.getDefaultValues());
         System.err.printf("     source: %s\n", src.toString());
 
-        val mapping = mapper.map(src);
+        val mapping = mapper.map(src.toString());
         val dest = mapping.getDestLocation();
         System.err.printf("destination: %s\n", dest.toString());
 
         val generator = new ObjectFilterGenerator(streamDef);
         val operators = generator.generate();
         val filter = factory.compose(operators);
-        val result = new FilterResult(src.urlString(), dest.urlString());
+        val result = new FilterResult(src.toString(), dest.urlString());
         val streamName = mapping.getStreamName();
         preprocessor.applyFilter(filter, src, dest, result, streamName);
         System.err.printf("     result: input rows=%d, output rows=%d, error rows=%d\n", result.inputRows, result.outputRows, result.errorRows);

--- a/src/main/java/org/bricolages/streaming/s3/ObjectMapper.java
+++ b/src/main/java/org/bricolages/streaming/s3/ObjectMapper.java
@@ -1,5 +1,7 @@
 package org.bricolages.streaming.s3;
 import org.bricolages.streaming.ConfigError;
+import org.bricolages.streaming.SourceLocator;
+
 import java.util.Objects;
 import java.nio.file.Paths;
 import java.util.List;
@@ -25,9 +27,9 @@ public class ObjectMapper {
         }
     }
 
-    public Result map(S3ObjectLocation src) throws ConfigError {
+    public Result map(String src) throws ConfigError {
         for (Entry ent : entries) {
-            Matcher m = ent.sourcePattern().matcher(src.urlString());
+            Matcher m = ent.sourcePattern().matcher(src);
             if (m.matches()) {
                 return new Result(
                     safeSubst(ent.streamName, m),

--- a/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
+++ b/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
@@ -27,6 +27,16 @@ public class ObjectMapperTest {
         assertEquals("schema.table", result.getStreamName());
         assertNull(map.map("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
     }
+
+    @Test
+    public void map_localfile() throws Exception {
+        val map = newMapper(entry("file:/(?:.+/)?src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "dest-bucket", "dest-prefix/$1", "", "$2"));
+        map.check();
+        val result = map.map("file:/path/to/src-bucket/src-prefix/schema.table/datafile.json.gz");
+        assertEquals(loc("s3://dest-bucket/dest-prefix/schema.table/datafile.json.gz"), result.getDestLocation());
+        assertEquals("schema.table", result.getStreamName());
+        assertNull(map.map("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
+    }
     
     @Test(expected=ConfigError.class)
     public void map_baddest() throws Exception {

--- a/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
+++ b/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
@@ -22,17 +22,17 @@ public class ObjectMapperTest {
     public void map() throws Exception {
         val map = newMapper(entry("s3://src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
-        val result = map.map(loc("s3://src-bucket/src-prefix/schema.table/datafile.json.gz"));
+        val result = map.map("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
         assertEquals(loc("s3://dest-bucket/dest-prefix/schema.table/datafile.json.gz"), result.getDestLocation());
         assertEquals("schema.table", result.getStreamName());
-        assertNull(map.map(loc("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz")));
+        assertNull(map.map("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
     }
     
     @Test(expected=ConfigError.class)
     public void map_baddest() throws Exception {
         val map = newMapper(entry("s3://src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$3", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
-        map.map(loc("s3://src-bucket/src-prefix/schema.table/datafile.json.gz"));
+        map.map("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
     }
 
     @Test(expected=ConfigError.class)


### PR DESCRIPTION
`--map-url` や `--process-url` に渡す入力データの URL として、 `s3:` から始まる S3 の URL の他に、ローカルファイルへのパスも受け付けるようにしました。

mapping をする際には、`file:` + 絶対パスの形式に正規化されます。