### PR TITLE
Accept rails datetime format

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/Op.java
+++ b/src/main/java/org/bricolages/streaming/filter/Op.java
@@ -95,7 +95,7 @@ public abstract class Op {
 
     static protected final DateTimeFormatter RUBY_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss xxxx");
     static protected final DateTimeFormatter RAILS_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
-    static final Pattern TIMESTAMP_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)? ?(?:Z|\\w{0,5}([+-]\\d{2}:?\\d{2})?)");
+    static final Pattern TIMESTAMP_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)? ?(?:Z|\\w{1,5}|[+-]\\d{2}:?\\d{2})?");
 
     protected OffsetDateTime getOffsetDateTime(Object value, ZoneOffset defaultOffset, boolean truncate) throws FilterException {
         if (! (value instanceof String)) {

--- a/src/test/java/org/bricolages/streaming/filter/TimeZoneOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TimeZoneOpTest.java
@@ -22,6 +22,7 @@ public class TimeZoneOpTest {
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01T10:41:06Z", null));
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01T10:41:06+00:00", null));
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01 10:41:06 +0000", null));
+        assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01 10:41:06 UTC", null));
     }
 
     @Test


### PR DESCRIPTION
TimeZoneオペレータで、`2017-04-19 12:46:10 UTC`のようなフォーマットのデータを扱えるようにします。