### PR TITLE
[fix] float op wrongly rejected negative float values

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/FloatOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/FloatOp.java
@@ -16,11 +16,8 @@ public class FloatOp extends SingleColumnOp {
     public Object applyValue(Object rawValue, Record record) throws FilterException {
         if (rawValue == null) return null;
         float value = getFloat(rawValue);
-        if (Float.MIN_VALUE <= value && value <= Float.MAX_VALUE) {
-            return Float.valueOf(value);
-        }
-        else {
-            return null;
-        }
+        // getFloat returns Inf/-Inf for too big/small value
+        if (Float.isInfinite(value) || Float.isNaN(value)) return null;
+        return Float.valueOf(value);
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/FloatOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/FloatOpTest.java
@@ -31,18 +31,23 @@ public class FloatOpTest {
             val out = op.apply(rec);
             assertEquals("{\"n\":123.4}", out.serialize());
         }
+        {
+            val rec = Record.parse("{\"n\":-1.234}");
+            val out = op.apply(rec);
+            assertEquals("{\"n\":-1.234}", out.serialize());
+        }
     }
 
     @Test
     public void apply_too_large_value() throws Exception {
         val f = new FloatOp(null);
-        assertEquals(null, f.applyValue(Double.MAX_VALUE, null));
+        assertEquals(null, f.applyValue(440282346638528860000000000000000000000.0, null));
     }
 
     @Test
     public void apply_too_small_value() throws Exception {
         val f = new FloatOp(null);
-        assertEquals(null, f.applyValue(Double.MIN_VALUE, null));
+        assertEquals(null, f.applyValue(-440282346638528860000000000000000000000.0, null));
     }
 
     @Test(expected = FilterException.class)


### PR DESCRIPTION
Java's `Float.MIN_VALUE` is not negative smallest number, its absolute minimum value.

FYI @KOBA789 