### PR TITLE
Treat empty YAML value as not null but empty value

### DIFF
--- a/src/main/java/org/bricolages/streaming/Config.java
+++ b/src/main/java/org/bricolages/streaming/Config.java
@@ -3,7 +3,6 @@ package org.bricolages.streaming;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.bricolages.streaming.preflight.domains.DomainDefaultValues;
 import org.bricolages.streaming.s3.ObjectMapper;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -41,7 +40,4 @@ public class Config {
     @Getter
     @Setter
     private String destDs;
-    @Getter
-    @Setter
-    private DomainDefaultValues defaults;
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
@@ -7,11 +7,13 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("date")
 @MultilineDescription("Date time")
+@NoArgsConstructor
 public class DateDomain implements ColumnParametersEntry {
     @Getter
     @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
@@ -38,4 +40,7 @@ public class DateDomain implements ColumnParametersEntry {
         this.sourceOffset = this.sourceOffset == null ? defaultValue.sourceOffset : this.sourceOffset;
         this.targetOffset = this.targetOffset == null ? defaultValue.targetOffset : this.targetOffset;
     }
+
+    // This is necessary to accept empty value
+    @JsonCreator public DateDomain(String nil) { /* noop */ }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DomainDefaultValues.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DomainDefaultValues.java
@@ -1,12 +1,5 @@
 package org.bricolages.streaming.preflight.domains;
 
-import java.io.IOException;
-import java.io.Reader;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import lombok.*;
 
 public class DomainDefaultValues {

--- a/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
@@ -8,6 +8,7 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
@@ -16,6 +17,7 @@ import lombok.*;
     "Timestamp indicating when log was recorded",
     "Usually this column becomes sortkey.",
 })
+@NoArgsConstructor
 public class LogTimeDomain implements ColumnParametersEntry {
     @Getter
     @MultilineDescription("Expected source data timezone, given by the string like '+00:00'")
@@ -50,4 +52,7 @@ public class LogTimeDomain implements ColumnParametersEntry {
         this.targetOffset = this.targetOffset == null ? defaultValue.targetOffset : this.targetOffset;
         this.sourceColumn = this.sourceColumn == null ? defaultValue.sourceColumn : this.sourceColumn;
     }
+
+    // This is necessary to accept empty value
+    @JsonCreator public LogTimeDomain(String nil) { /* noop */ }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
@@ -7,11 +7,13 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
 @JsonTypeName("unixtime")
 @MultilineDescription("Timestamp converted from unix time")
+@NoArgsConstructor
 public class UnixtimeDomain implements ColumnParametersEntry {
     @Getter
     @MultilineDescription("Target timezone, given by the string like '+09:00'")
@@ -33,4 +35,7 @@ public class UnixtimeDomain implements ColumnParametersEntry {
         if (defaultValue == null) { return; }
         this.zoneOffset = this.zoneOffset == null ? defaultValue.zoneOffset : this.zoneOffset;
     }
+
+    // This is necessary to accept empty value
+    @JsonCreator public UnixtimeDomain(String nil) { /* noop */ }
 }


### PR DESCRIPTION
今まで、単に
```
time: !unixtime
```
と書くと、`time` プロパティの値が null となり、デフォルト値の適用もできずにぬるぽでコケてしまっていました。

これを修正し、値が空文字列の場合には空の値をプロパティにセットするようにします。